### PR TITLE
explicitely set UID and GID for ticktock user in docker 

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,6 +3,8 @@
 #     --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
 #     --build-arg GIT_COMMIT=$(git log -1 --pretty=format:%h)
 #     --build-arg VERSION=0.1.3-alpha --no-cache=true --add-host=ticktock
+#     --build-arg UID=1000
+#     --build-arg GID=1000
 #
 # To inspect the image by running it:
 #   docker run --rm -it --entrypoint=/bin/bash ytyou/ticktock:latest
@@ -32,6 +34,8 @@ ARG BUILD_DATE
 ARG GIT_COMMIT
 ARG VERSION
 ARG DEBIAN_FRONTEND=noninteractive
+ARG UID=1000
+ARG GID=1000
 
 LABEL name="TickTock" version="$VERSION"
 LABEL build-date="$BUILD_DATE" git-commit="$GIT_COMMIT"
@@ -48,7 +52,8 @@ RUN apt-get update && apt-get install -y \
   curl \
   nano
 
-RUN useradd -M -U ticktock
+RUN addgroup --quiet --gid ${GID} ticktock && \
+  adduser --quiet --uid ${UID} --disabled-login --disabled-password --no-create-home --gecos "" --ingroup ticktock ticktock
 
 RUN mkdir -p /var/lib/ticktock && \
   chown ticktock:ticktock /var/lib/ticktock

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -7,6 +7,8 @@ TAGL="latest"
 DOCKERFILE="../Dockerfile"
 _TEST=0
 _GRAFANA=0
+_UID=1000
+_GID=1000
 
 # process command line arguments
 while [[ $# -gt 0 ]]
@@ -21,6 +23,17 @@ do
         --test)
         _TEST=1
         ;;
+
+        --uid)
+        shift
+        _UID=$1
+        ;;
+
+        --gid)
+        shift
+        _GID=$1
+        ;;
+
     esac
     shift
 done
@@ -114,6 +127,8 @@ docker build -f $DOCKERFILE --tag ytyou/ticktock:${TAGV} --tag ytyou/ticktock:${
     --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
     --build-arg GIT_COMMIT=$(git log -1 --pretty=format:%h) \
     --build-arg VERSION=${TT_VERSION}-${STAGE} --add-host=ticktock:127.0.0.1 \
+    --build-arg UID=${_UID} \
+    --build-arg GID=${_GID} \
     --rm $BUILD_OPT .
 popd
 


### PR DESCRIPTION
When using a mounted volume for config, logs and data of ticktock, the user and group IDs of the tocktock user in container and the owner of the volume mount directory should match to prevent access permission quirks.

The default GID and UID used by `addgroup` and `adduser` is 1000 each. If the target directory of the docker volume belongs to a user with different UID/GID, the ticktock docker container fails to access the files and/or create directories and data files.

To overcome this, `--uid` and `--gid` were added to `docker-build.sh` and the `Dockerfile` extended to set them accordingly.